### PR TITLE
inject request and response into controller

### DIFF
--- a/yaroo/lib/http/http.dart
+++ b/yaroo/lib/http/http.dart
@@ -2,9 +2,10 @@
 
 import 'dart:async';
 
-import 'package:meta/meta_meta.dart';
 import 'package:yaroo/src/_reflector/reflector.dart';
 import 'package:yaroo/src/core.dart';
+
+import 'http.dart';
 
 export 'package:pharaoh/pharaoh.dart'
     show
@@ -20,23 +21,43 @@ export 'package:pharaoh/pharaoh.dart'
         useShelfMiddleware;
 
 @inject
-abstract class BaseController extends AppInstance {}
+abstract class ApplicationController extends AppInstance {
+  late final Request request;
+
+  late final Response response;
+
+  Map<String, dynamic> get params => request.params;
+
+  Map<String, dynamic> get query => request.query;
+
+  Map<String, dynamic> get headers => request.headers;
+
+  get body => request.body;
+
+  Response badRequest([String? message]) {
+    const status = 422;
+    if (message == null) return response.status(status);
+    return response.json({'message': message}, statusCode: status);
+  }
+
+  Response notFound([String? message]) {
+    const status = 404;
+    if (message == null) return response.status(status);
+    return response.json({'message': message}, statusCode: status);
+  }
+
+  Response jsonResponse(data, {int statusCode = 200}) {
+    return response.json(data, statusCode: statusCode);
+  }
+
+  Response redirectTo(String url, {int statusCode = 302}) {
+    return response.redirect(url, statusCode);
+  }
+}
 
 @inject
 abstract class ServiceProvider extends AppInstance {
   static List<Type> get defaultProviders => [AppServiceProvider];
 
   FutureOr<void> boot();
-}
-
-@Target({TargetKind.parameter})
-class Param {
-  const Param(String name);
-}
-
-@Target({TargetKind.parameter})
-class Body {
-  final String? param;
-
-  const Body({this.param});
 }

--- a/yaroo/lib/src/_reflector/reflector.dart
+++ b/yaroo/lib/src/_reflector/reflector.dart
@@ -64,7 +64,7 @@ ControllerMethod parseControllerMethod(ControllerMethodDefinition defn) {
   final method = defn.$2;
 
   final ctrlMirror = inject.reflectType(type) as r.ClassMirror;
-  if (ctrlMirror.superclass?.reflectedType != BaseController) {
+  if (ctrlMirror.superclass?.reflectedType != ApplicationController) {
     throw ArgumentError('$type must extend BaseController');
   }
 
@@ -74,8 +74,9 @@ ControllerMethod parseControllerMethod(ControllerMethodDefinition defn) {
     throw ArgumentError('$type does not have method  #${symbolToString(method)}');
   }
 
-  // final parameters = actualMethod.parameters.map((e) => e.reflectedType);
-  // print(parameters);
+  if (actualMethod.parameters.isNotEmpty) {
+    throw ArgumentError.value('$type.${actualMethod.simpleName}', null, 'Controller methods cannot have parameters');
+  }
 
   return ControllerMethod(defn);
 }

--- a/yaroo/test/router_test.dart
+++ b/yaroo/test/router_test.dart
@@ -4,7 +4,7 @@ import 'package:yaroo/yaroo.dart';
 
 import './router_test.reflectable.dart';
 
-class TestController extends BaseController {
+class TestController extends ApplicationController {
   void create() {}
 
   void index() {}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

We now inject the current `Request` and `Response` objects into the controller instance when created. This way it's easy to reference things like `headers`, `body`, `params` and `query-params` without needing to reflect on the controller instance.

I took inspiration from Rails `ApplicationController` for this one particularly. 
```ruby
class ClientsController < ApplicationController
  # This action uses query string parameters because it gets run
  # by an HTTP GET request, but this does not make any difference
  # to how the parameters are accessed. The URL for
  # this action would look like this to list activated
  # clients: /clients?status=activated
  def index
    if params[:status] == "activated"
      @clients = Client.activated
    else
      @clients = Client.inactivated
    end
  end
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
